### PR TITLE
update googletest version to 1.11.0

### DIFF
--- a/.github/workflows/centos5.yml
+++ b/.github/workflows/centos5.yml
@@ -15,8 +15,6 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Checkout Old Version googletest
-      run: cd third_party/googletest && git checkout v1.8.x && ../..
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DKIWI_USE_MIMALLOC=0 ..
     - name: Build

--- a/.github/workflows/centos5.yml
+++ b/.github/workflows/centos5.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
+    - name: Checkout Old Version googletest
+      run: cd third_party/googletest && git checkout v1.8.x && ../..
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DKIWI_USE_MIMALLOC=0 ..
     - name: Build

--- a/.github/workflows/centos5.yml
+++ b/.github/workflows/centos5.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
+    - name: Checkout Old Version googletest
+      run: cd third_party/googletest && git checkout v1.8.x && cd ../..
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DKIWI_USE_MIMALLOC=0 ..
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
+    - name: Checkout Old Version googletest
+      run: cd third_party/googletest && git checkout v1.8.x && cd ../..
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DKIWI_USE_MIMALLOC=0 ..
     - name: Build

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,4 +11,4 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
-	branch = v1.8.x
+	branch = master


### PR DESCRIPTION
fixed #34 

existing submodule googletest v1.8.x caused cmake deprecation warning, 
I updated googletest version to 1.11.0.