### PR TITLE
[WIP] Add wordPosition to TokenInfo

### DIFF
--- a/include/kiwi/Types.h
+++ b/include/kiwi/Types.h
@@ -199,6 +199,7 @@ namespace kiwi
 		std::u16string str; /**< 형태 */
 		uint32_t position = 0; /**< 시작 위치(UTF16 문자 기준) */
 		uint16_t length = 0; /**< 길이(UTF16 문자 기준) */
+    uint16_t wordPosition = 0;
 		POSTag tag = POSTag::unknown; /**< 품사 태그 */
 		const Morpheme* morph = nullptr; /**< 기타 형태소 정보에 대한 포인터 (OOV인 경우 nullptr) */
 
@@ -207,9 +208,10 @@ namespace kiwi
 		TokenInfo(const std::u16string& _str,
 			POSTag _tag = POSTag::unknown,
 			uint16_t _length = 0,
-			uint32_t _position = 0
+			uint32_t _position = 0,
+      uint16_t _wordPosition = 0
 		)
-			: str{ _str }, position{ _position }, length{ _length }, tag{ _tag }
+			: str{ _str }, position{ _position }, length{ _length }, wordPosition{ _wordPosition }, tag{ _tag }
 		{
 		}
 

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -70,3 +70,16 @@ TEST(KiwiCpp, AnalyzeError01)
 	res = kiwi.analyze(u"잤는데", Match::all);
 	EXPECT_EQ(res.first[0].str, std::u16string{ u"자" });
 }
+
+TEST(KiwiCpp, AnalyzeWithWordPosition)
+{
+  std::u16string testSentence = u"나 정말 배불렄ㅋㅋ"; 
+	Kiwi kiwi = KiwiBuilder{ MODEL_PATH, 0, BuildOption::none }.build();
+	TokenResult tokenResult = kiwi.analyze(testSentence, Match::all);
+  std::vector<TokenInfo> tokenInfoList = tokenResult.first;
+
+  EXPECT_EQ(tokenInfoList[0].wordPosition, 0);
+  EXPECT_EQ(tokenInfoList[1].wordPosition, 1);
+  EXPECT_EQ(tokenInfoList[2].wordPosition, 2);
+  EXPECT_EQ(tokenInfoList[3].wordPosition, 2);
+}


### PR DESCRIPTION
By issue #31, wordPosition is added for the sake of storing word orders of original sentence.
This commit includes changes only in `TokenInfo` struct and some test codes.
Critical parts that storing word positions are not developed yet. (WIP)