### PR TITLE
feat: add make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ file(GLOB KIWI_INCLUDE_FILES include/kiwi/*.h include/kiwi/*.hpp)
 set_target_properties(${PROJECT_NAME}
     PROPERTIES PUBLIC_HEADER "${KIWI_INCLUDE_FILES}"
 )
+install(TARGETS ${PROJECT_NAME}_static PUBLIC_HEADER DESTINATION include/kiwi)
 install(TARGETS ${PROJECT_NAME} PUBLIC_HEADER DESTINATION include/kiwi)
 
 target_compile_options("${PROJECT_NAME}_static" PRIVATE "${ADDITIONAL_FLAGS}")


### PR DESCRIPTION
- public header files will be installed into user's local include directory such
that Kiwi can be used in non cmake projects.
