### PR TITLE
Joiner.cpp 에서 -Wswitch warning 이 발생하는 부분 수정 (on clang)

### DIFF
--- a/src/Joiner.cpp
+++ b/src/Joiner.cpp
@@ -48,6 +48,8 @@ namespace kiwi
 			case POSTag::w_url:
 			case POSTag::w_mention:
 				return true;
+			default:
+				return false;
 			}
 			return false;
 		}


### PR DESCRIPTION
POSTag 의 나머지 부분에 대한 case가 없다고 warning을 하는 것 같아 default를 추가하였습니다. 