### PR TITLE
`AutoJoiner` 개선

### DIFF
--- a/include/kiwi/Joiner.h
+++ b/include/kiwi/Joiner.h
@@ -28,6 +28,7 @@ namespace kiwi
 			template<class LmState> friend struct Candidate;
 			const CompiledRule* cr = nullptr;
 			KString stack;
+			std::vector<std::pair<uint32_t, uint32_t>> ranges;
 			size_t activeStart = 0;
 			POSTag lastTag = POSTag::unknown, anteLastTag = POSTag::unknown;
 
@@ -45,8 +46,8 @@ namespace kiwi
 			void add(const std::u16string& form, POSTag tag, Space space = Space::none);
 			void add(const char16_t* form, POSTag tag, Space space = Space::none);
 
-			std::u16string getU16() const;
-			std::string getU8() const;
+			std::u16string getU16(std::vector<std::pair<uint32_t, uint32_t>>* rangesOut = nullptr) const;
+			std::string getU8(std::vector<std::pair<uint32_t, uint32_t>>* rangesOut = nullptr) const;
 		};
 
 		template<class LmState>
@@ -115,8 +116,8 @@ namespace kiwi
 			void add(const std::u16string& form, POSTag tag, bool inferRegularity = true, Space space = Space::none);
 			void add(const char16_t* form, POSTag tag, bool inferRegularity = true, Space space = Space::none);
 
-			std::u16string getU16() const;
-			std::string getU8() const;
+			std::u16string getU16(std::vector<std::pair<uint32_t, uint32_t>>* rangesOut = nullptr) const;
+			std::string getU8(std::vector<std::pair<uint32_t, uint32_t>>* rangesOut = nullptr) const;
 		};
 	}
 }

--- a/include/kiwi/Utils.h
+++ b/include/kiwi/Utils.h
@@ -108,6 +108,31 @@ namespace kiwi
 		return ret;
 	}
 
+	template<class It, class Ty, class Alloc>
+	inline std::u16string joinHangul(It first, It last, std::vector<Ty, Alloc>& positionOut)
+	{
+		std::u16string ret;
+		ret.reserve(std::distance(first, last));
+		positionOut.clear();
+		positionOut.reserve(std::distance(first, last));
+		for (; first != last; ++first)
+		{
+			auto c = *first;
+			if (isHangulCoda(c) && !ret.empty() && isHangulSyllable(ret.back()))
+			{
+				if ((ret.back() - 0xAC00) % 28) ret.push_back(c);
+				else ret.back() += c - 0x11A7;
+				positionOut.emplace_back(ret.size() - 1);
+			}
+			else
+			{
+				ret.push_back(c);
+				positionOut.emplace_back(ret.size() - 1);
+			}
+		}
+		return ret;
+	}
+
 	inline std::u16string joinHangul(const KString& hangul)
 	{
 		return joinHangul(hangul.begin(), hangul.end());

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -1147,7 +1147,7 @@ Vector<KString> CompiledRule::combineImpl(
 	return ret;
 }
 
-pair<KString, size_t> CompiledRule::combineOneImpl(
+tuple<KString, size_t, size_t> CompiledRule::combineOneImpl(
 	U16StringView leftForm, POSTag leftTag,
 	U16StringView rightForm, POSTag rightTag,
 	CondVowel cv, CondPolarity cp
@@ -1163,12 +1163,12 @@ pair<KString, size_t> CompiledRule::combineOneImpl(
 	{
 		for (auto& p : mapbox::util::apply_visitor(CombineVisitor{ leftForm, rightForm }, dfa[it->second]))
 		{
-			if(p.score >= 0) return make_pair(p.str, p.rightBegin);
+			if(p.score >= 0) return make_tuple(p.str, p.leftEnd, p.rightBegin);
 			KString ret;
 			ret.reserve(leftForm.size() + rightForm.size());
 			ret.insert(ret.end(), leftForm.begin(), leftForm.end());
 			ret.insert(ret.end(), rightForm.begin(), rightForm.end());
-			return make_pair(ret, leftForm.size());
+			return make_tuple(ret, leftForm.size(), leftForm.size());
 		}
 	}
 
@@ -1183,7 +1183,7 @@ pair<KString, size_t> CompiledRule::combineOneImpl(
 		{
 			for (auto& p : mapbox::util::apply_visitor(CombineVisitor{ leftForm, rightForm }, dfa[it->second]))
 			{
-				return make_pair(p.str, p.rightBegin);
+				return make_tuple(p.str, p.leftEnd, p.rightBegin);
 			}
 		}
 	}
@@ -1198,14 +1198,14 @@ pair<KString, size_t> CompiledRule::combineOneImpl(
 			ret.insert(ret.end(), leftForm.begin(), leftForm.end());
 			ret.push_back(u'아'); // `어`를 `아`로 교체하여 삽입
 			ret.insert(ret.end(), rightForm.begin() + 1, rightForm.end());
-			return make_pair(ret, leftForm.size());
+			return make_tuple(ret, leftForm.size(), leftForm.size());
 		}
 	}
 	KString ret;
 	ret.reserve(leftForm.size() + rightForm.size());
 	ret.insert(ret.end(), leftForm.begin(), leftForm.end());
 	ret.insert(ret.end(), rightForm.begin(), rightForm.end());
-	return make_pair(ret, leftForm.size());
+	return make_tuple(ret, leftForm.size(), leftForm.size());
 }
 
 Vector<tuple<size_t, size_t, CondPolarity>> CompiledRule::testLeftPattern(U16StringView leftForm, size_t ruleId) const

--- a/src/Combiner.h
+++ b/src/Combiner.h
@@ -215,7 +215,10 @@ namespace kiwi
 				CondVowel cv = CondVowel::none, CondPolarity cp = CondPolarity::none
 			) const;
 
-			std::pair<KString, size_t> combineOneImpl(
+			/**
+			* @return tuple(combinedForm, leftFormBoundary, rightFormBoundary)
+			*/
+			std::tuple<KString, size_t, size_t> combineOneImpl(
 				U16StringView leftForm, POSTag leftTag,
 				U16StringView rightForm, POSTag rightTag,
 				CondVowel cv = CondVowel::none, CondPolarity cp = CondPolarity::none

--- a/src/Joiner.cpp
+++ b/src/Joiner.cpp
@@ -1,4 +1,4 @@
-#include "Joiner.hpp"
+﻿#include "Joiner.hpp"
 #include "FrozenTrie.hpp"
 
 using namespace std;
@@ -300,16 +300,23 @@ namespace kiwi
 				if (!node) break;
 			}
 
+			// prevent unknown or partial tag
+			POSTag fixedTag = tag;
+			if (tag == POSTag::unknown || tag == POSTag::p)
+			{
+				fixedTag = POSTag::nnp;
+			}
+
 			if (node && kiwi->formTrie.hasMatch(formHead = node->val(kiwi->formTrie)))
 			{
 				Vector<const Morpheme*> cands;
 				foreachMorpheme(formHead, [&](const Morpheme* m)
 				{
-					if (inferRegularity && clearIrregular(m->tag) == clearIrregular(tag))
+					if (inferRegularity && clearIrregular(m->tag) == clearIrregular(fixedTag))
 					{
 						cands.emplace_back(m);
 					}
-					else if (!inferRegularity && m->tag == tag)
+					else if (!inferRegularity && m->tag == fixedTag)
 					{
 						cands.emplace_back(m);
 					}
@@ -317,7 +324,7 @@ namespace kiwi
 				
 				if (cands.size() <= 1)
 				{
-					auto lmId = cands.empty() ? getDefaultMorphemeId(clearIrregular(tag)) : cands[0]->lmMorphemeId;
+					auto lmId = cands.empty() ? getDefaultMorphemeId(clearIrregular(fixedTag)) : cands[0]->lmMorphemeId;
 					if (!cands.empty()) tag = cands[0]->tag;
 					for (auto& cand : candidates)
 					{
@@ -373,7 +380,7 @@ namespace kiwi
 			}
 			else
 			{
-				auto lmId = getDefaultMorphemeId(clearIrregular(tag));
+				auto lmId = getDefaultMorphemeId(clearIrregular(fixedTag));
 				for (auto& cand : candidates)
 				{
 					cand.score += cand.lmState.next(kiwi->langMdl, lmId);

--- a/src/Joiner.cpp
+++ b/src/Joiner.cpp
@@ -26,6 +26,7 @@ namespace kiwi
 			if (l == POSTag::sn && r == POSTag::nr) return false;
 			if (l == POSTag::sso || l == POSTag::ssc) return false;
 			if (r == POSTag::sso) return true;
+			if ((isJClass(l) || isEClass(l)) && r == POSTag::ss) return true;
 
 			if (r == POSTag::vx && rform.size() == 1 && (rform[0] == u'하' || rform[0] == u'지')) return false;
 


### PR DESCRIPTION
* `AutoJoiner::getU8/16`에 `rangesOut` 인자 추가. `rangesOut`을 통해 결합된 이후 각 형태소들의 위치 정보를 확인할 수 있음
* `AutoJoiner`로 수많은 형태소를 결합할 때의 속도 개선
* `AutoJoiner`에 UN 태그를 입력할 때 발생하는 버그 수정