### PR TITLE
공백 없는 긴 텍스트에 대한 효율적인 분할

### DIFF
--- a/src/KTrie.cpp
+++ b/src/KTrie.cpp
@@ -514,6 +514,12 @@ size_t kiwi::splitByTrie(
 				break;
 			}
 		}
+		// 혹은 공백 문자가 아예 없는 경우 너무 길어지는 것을 방지하기 위해 강제로 중단
+		else if (n >= 8192)
+		{
+			lastChrType = chrType;
+			break;
+		}
 
 		// 공백문자를 무시하고 분할 진행
 		if (chrType == POSTag::unknown)


### PR DESCRIPTION
### bab2min/kiwipiepy#158 에서 제보된 문제를 해결하기 위한 PR

`removeUnconnected` 함수에서 graph의 최대 길이를 `uint16_t` 범위로 가정하고 있었는데, 이를 초과한 입력이 들어오는 경우 overflow가 발생하여 graph 조작에 오류가 발생하고 이게 segmentation fault에까지 이르게 된다. `splitByTrie`는 문장의 종결 지점(구두점 뒤 공백)이나 길이가 4096을 넘는 공백지점에서만 강제로 그래프를 분할하도록 하는데, 이 때문에 공백 없이 길이가 4096을 넘어가는 경우 그래프가 분할되지 않고 전체가 긴 그래프로 처리되게 된다. 이를 방지하기 위해 8192글자를 넘는 입력에 대해서는 공백이 없더라도 강제로 그래프를 분할하도록 수정하였음.

추가로 `splitByTrie`에서는 그래프 내 노드 삽입 여부를 판단하기 위해 이미 삽입된 노드 중 시작/끝지점이 중복되는 경우를 탐색하는데, 이 부분에서 linear 탐색 알고리즘을 사용하고 있어서 그래프가 길어질수록 탐색 시간이 길어지는 문제가 있었음(그래프 길이를 n이라고 할때 함수 전체의 시간복잡도가 `O(n^2)`이 된다). 그래프 구축 시 삽입되는 노드의 순서를 잘 조절하여 탐색 범위를 constant로 줄이는 최적화를 수행하였고 덕분에 긴 입력에서 발생하는 `splitByTrie` 부분의 병목을 개선하였음.