### PR TITLE
Pretokenized span 개선

### DIFF
--- a/include/kiwi/Types.h
+++ b/include/kiwi/Types.h
@@ -243,12 +243,7 @@ namespace kiwi
 
     inline constexpr bool areTagsEqual(POSTag a, POSTag b, bool ignoreRegularity = false)
     {
-        if (ignoreRegularity)
-        {
-            a = clearIrregular(a);
-            b = clearIrregular(b);
-        }
-        return a == b;
+        return ignoreRegularity ? (clearIrregular(a) == clearIrregular(b)) : (a == b);
     }
 
 	constexpr size_t defaultTagSize = (size_t)POSTag::p;

--- a/include/kiwi/Types.h
+++ b/include/kiwi/Types.h
@@ -241,6 +241,16 @@ namespace kiwi
 		return irregular ? setIrregular(tag) : clearIrregular(tag);
 	}
 
+    inline constexpr bool areTagsEqual(POSTag a, POSTag b, bool ignoreRegularity = false)
+    {
+        if (ignoreRegularity)
+        {
+            a = clearIrregular(a);
+            b = clearIrregular(b);
+        }
+        return a == b;
+    }
+
 	constexpr size_t defaultTagSize = (size_t)POSTag::p;
 
 	/**
@@ -349,9 +359,10 @@ namespace kiwi
 		std::u16string form;
 		uint32_t begin = -1, end = -1;
 		POSTag tag = POSTag::unknown;
+		uint8_t inferRegularity = 1;
 
-		BasicToken(const std::u16string& _form = {}, uint32_t _begin = -1, uint32_t _end = -1, POSTag _tag = POSTag::unknown)
-			: form{ _form }, begin{ _begin }, end{ _end }, tag{ _tag }
+		BasicToken(const std::u16string& _form = {}, uint32_t _begin = -1, uint32_t _end = -1, POSTag _tag = POSTag::unknown, uint8_t _inferRegularity = 1)
+			: form{ _form }, begin{ _begin }, end{ _end }, tag{ _tag }, inferRegularity{ _inferRegularity }
 		{}
 	};
 

--- a/src/Joiner.cpp
+++ b/src/Joiner.cpp
@@ -312,11 +312,7 @@ namespace kiwi
 				Vector<const Morpheme*> cands;
 				foreachMorpheme(formHead, [&](const Morpheme* m)
 				{
-					if (inferRegularity && clearIrregular(m->tag) == clearIrregular(fixedTag))
-					{
-						cands.emplace_back(m);
-					}
-					else if (!inferRegularity && m->tag == fixedTag)
+					if (areTagsEqual(m->tag, fixedTag, inferRegularity))
 					{
 						cands.emplace_back(m);
 					}
@@ -412,7 +408,7 @@ namespace kiwi
 						Vector<const Morpheme*> cands;
 						foreachMorpheme(formHead, [&](const Morpheme* m)
 						{
-							if (clearIrregular(m->tag) == clearIrregular(tag))
+							if (areTagsEqual(m->tag, tag, true))
 							{
 								cands.emplace_back(m);
 							}

--- a/src/Kiwi.cpp
+++ b/src/Kiwi.cpp
@@ -247,7 +247,7 @@ namespace kiwi
 				case POSTag::vcp:
 				case POSTag::etm:
 				case POSTag::ec:
-					if (t.tag == POSTag::jx && *t.morph->kform == u"요")
+					if (t.tag == POSTag::jx && t.morph && *t.morph->kform == u"요")
 					{
 						if (state == State::ef)
 						{

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -271,6 +271,34 @@ TEST(KiwiCpp, Pretokenized)
 		EXPECT_EQ(res[13].str, u"매트");
 		EXPECT_EQ(res[13].tag, POSTag::nng);
 	}
+
+	{
+		std::vector<PretokenizedSpan> pretokenized = {
+			PretokenizedSpan{ 9, 10, { BasicToken{ u"가", 0, 1, POSTag::jks } } },
+			PretokenizedSpan{ 16, 17, { BasicToken{ u"에", 0, 1, POSTag::jkb } } },
+		};
+
+		auto ref = kiwi.analyze(str, Match::allWithNormalizing).first;
+		res = kiwi.analyze(str, Match::allWithNormalizing, nullptr, pretokenized).first;
+		EXPECT_EQ(res[2].tag, POSTag::jks);
+		EXPECT_EQ(res[2].morph, ref[2].morph);
+		EXPECT_EQ(res[2].score, ref[2].score);
+		EXPECT_EQ(res[5].tag, POSTag::jkb);
+		EXPECT_EQ(res[5].morph, ref[5].morph);
+		EXPECT_EQ(res[5].score, ref[5].score);
+	}
+
+	{
+		auto str2 = u"길을 걷다";
+		std::vector<PretokenizedSpan> pretokenized = {
+			PretokenizedSpan{ 3, 4, { BasicToken{ u"걷", 0, 1, POSTag::vv } } },
+		};
+
+		auto ref = kiwi.analyze(str2, Match::allWithNormalizing).first;
+		res = kiwi.analyze(str2, Match::allWithNormalizing, nullptr, pretokenized).first;
+		EXPECT_EQ(res[2].tag, POSTag::vvi);
+		EXPECT_EQ(res[2].morph, ref[2].morph);
+	}
 }
 
 TEST(KiwiCpp, TagRoundTrip)


### PR DESCRIPTION
* pretokenized span으로 `JX` 태그가 아닌 문자열에 대해 `JX`를 강제로 부여할 때 발생하는 오류 수정
* pretokenized span으로 동사를 지정했을 때 문맥에 따라 규칙성 여부(`-R` / `-I`)를 자동으로 탐지하도록 기능 개선 