### PR TITLE
Fix length error

### DIFF
--- a/src/KTrie.cpp
+++ b/src/KTrie.cpp
@@ -1060,7 +1060,7 @@ size_t kiwi::splitByTrie(
 				lastSpecialEndPos * posMultiplier, specialStartPos * posMultiplier, 
 				str.substr(nonSpaces[lastSpecialEndPos], nonSpaces[specialStartPos] - nonSpaces[lastSpecialEndPos]));
 		}
-		if (appendNewNode(out, endPosMap, 
+		if (specialStartPos < nonSpaces.size() && appendNewNode(out, endPosMap,
 			specialStartPos * posMultiplier, nonSpaces.size() * posMultiplier, 
 			U16StringView{ &str[nonSpaces[specialStartPos]], n - nonSpaces[specialStartPos] }))
 		{

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -1484,3 +1484,16 @@ TEST(KiwiCpp, NestedSentenceSplit)
 		EXPECT_EQ(ranges.size(), 1);
 	}
 }
+
+TEST(KiwiCpp, IssueP172_LengthError)
+{
+	std::u16string text;
+	text += u"\n";
+	for (int i = 0; i < 4000; ++i)
+	{
+		text += u"좋은채팅사이트《35141561234.wang.com》";
+	}
+	Kiwi& kiwi = reuseKiwiInstance();
+	auto res = kiwi.analyze(text, Match::allWithNormalizing).first;
+	EXPECT_GT(res.size(), 0);
+}


### PR DESCRIPTION
bab2min/kiwipiepy#172 에서 제보된 std::length_error 예외 문제를 해결하는 패치.
공백 문자 없이 문자가 8192개(종성 분리된 한글 기준) 이상 연속하고 경계 지점에 특수 문자가 나타나는 상황에서 발생.
위 상황에서 새 노드를 삽입할 때 배열 경계를 벗어나는 값을 참조하는게 원인.