### PR TITLE
Move `ll` and `gamma` into `Node` structure

### DIFF
--- a/include/kiwi/Knlm.h
+++ b/include/kiwi/Knlm.h
@@ -31,6 +31,7 @@ namespace kiwi
 			KeyType num_nexts = 0;
 			DiffType lower = 0;
 			uint32_t next_offset = 0;
+			float ll = 0, gamma = 0;
 		};
 
 		class KnLangModelBase
@@ -56,9 +57,6 @@ namespace kiwi
 			virtual ptrdiff_t getLowerNode(ptrdiff_t node_idx) const = 0;
 
 			virtual size_t nonLeafNodeSize() const = 0;
-			virtual size_t llSize() const = 0;
-			virtual const float* getLLBuf() const = 0;
-			virtual const float* getGammaBuf() const = 0;
 			virtual const void* getExtraBuf() const = 0;
 
 			static std::unique_ptr<KnLangModelBase> create(utils::MemoryObject&& mem, ArchType archType = ArchType::none);


### PR DESCRIPTION
캐시 히트율 개선을 위해 `ll`과 `gamma` 데이터를 `Node` 안으로 옮기는 최적화 수행.