### PR TITLE
문장 시작 위치의 1., 2., 3. 등이 종종 SB 대신 SN로 분석되는 오류 수정

### DIFF
--- a/src/PathEvaluator.hpp
+++ b/src/PathEvaluator.hpp
@@ -90,7 +90,7 @@ namespace kiwi
 		Kiwi::SpecialMorph curMorphSpecialType;
 		size_t curMorphSbType;
 		int curMorphSbOrder;
-		bool vowelE, infJ, badPairOfL, positiveE, contractableE;
+		bool vowelE, infJ, badPairOfL, positiveE, contractableE, snEndswithPoint;
 		CondPolarity condP;
 
 		RuleBasedScorer(const Kiwi* kw, const Morpheme* curMorph, const KGraphNode* node)
@@ -103,6 +103,7 @@ namespace kiwi
 			badPairOfL{ isBadPairOfVerbL(curMorph) },
 			positiveE{ isEClass(curMorph->tag) && node->form && node->form->form[0] == u'아' },
 			contractableE{ isEClass(curMorph->tag) && curMorph->kform && !curMorph->kform->empty() && (*curMorph->kform)[0] == u'어' },
+			snEndswithPoint{ curMorph->tag == POSTag::sn && !node->uform.empty() && node->uform.back() == u'.'},
 			condP{ curMorph->polar }
 		{
 		}
@@ -170,6 +171,12 @@ namespace kiwi
 			if (curMorphSbType && prevSpState.bulletHash == hashSbTypeOrder(curMorphSbType, curMorphSbOrder))
 			{
 				accScore += 3;
+			}
+
+			// discount for SN ending with point at beginning of sentence
+			if (snEndswithPoint && prevMorpheme->tag == POSTag::unknown)
+			{
+				accScore -= 5;
 			}
 
 			return accScore;

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -2142,3 +2142,19 @@ TEST(KiwiCpp, Issue231)
 	EXPECT_EQ(tokens.size(), 1);
 	EXPECT_EQ(tokens[0].str, u"숫");
 }
+
+TEST(KiwiCpp, Issue246)
+{
+	auto& kiwi = reuseKiwiInstance();
+	for (auto s : {
+		u"1. 분석",
+		u"1. 해야 하는 일",
+		u"1. 해야 하는 업무",
+		u"1. 수학적 증명",
+		u"1. Dataset"
+	})
+	{
+		auto res = kiwi.analyze(s, 5, Match::allWithNormalizing);
+		EXPECT_EQ(res[0].first[0].tag, POSTag::sb) << " for input: " << utf16To8(s);
+	}
+}


### PR DESCRIPTION
#246 오류 수정
문장 시작 위치에서 SN과 SB 간의 확률이 유사한 값이 나와 서로 경쟁하는 경우가 있어서 일단은 규칙 기반으로 온점으로 끝나는 SN에 대해 페널티를 부여.