### PR TITLE
분석 결과에 원문 표면형 시작 정보 추가

### DIFF
--- a/include/kiwi/PatternMatcher.h
+++ b/include/kiwi/PatternMatcher.h
@@ -36,6 +36,7 @@ namespace kiwi
 		splitSaisiot = 1 << 25, /**< 사이시옷이 포함된 합성명사를 분리하여 매칭한다. */
 		mergeSaisiot = 1 << 26, /**< 사이시옷이 포함된 것으로 추정되는 명사를 결합하여 매칭한다. */
 		joinParticleYo = 1 << 27, /**< 어미(EC/EF)와 조사 "요/JX"를 통합하여 매칭한다 (예: 고/EC + 요/JX => 고요/EC) */
+		surfaceForm = 1 << 28, /**< 원문 표면형 경계를 TokenInfo::isSurfaceFormStart에 기록한다. */
 
 		useOldSplitter = 1 << 30,
 

--- a/include/kiwi/Types.h
+++ b/include/kiwi/Types.h
@@ -360,6 +360,7 @@ namespace kiwi
 		uint32_t pairedToken = -1; /**< SSO, SSC 태그에 속하는 형태소의 경우 쌍을 이루는 반대쪽 형태소의 위치(-1인 경우 해당하는 형태소가 없는 것을 뜻함) */
 		uint32_t subSentPosition = 0; /**< 인용부호나 괄호로 둘러싸인 하위 문장의 번호. 1부터 시작. 0인 경우 하위 문장이 아님을 뜻함 */
 		Dialect dialect = Dialect::standard; /**< 방언 정보 */
+		bool isSurfaceFormStart = false; /**< Match::surfaceForm 사용 시 이 Token이 새로운 원문 표면형에서 시작하는지 여부 */
 		const Morpheme* morph = nullptr; /**< 기타 형태소 정보에 대한 포인터 */
 
 		TokenInfo() = default;

--- a/src/Kiwi.cpp
+++ b/src/Kiwi.cpp
@@ -619,6 +619,8 @@ namespace kiwi
 		size_t topN, 
 		Match matchOptions,
 		bool integrateAllomorph,
+		bool trackSurfaceForm,
+		const KString& normalizedStr,
 		const Vector<uint32_t>& positionTable,
 		const Vector<uint16_t>& wordPositions,
 		const PretokenizedSpanGroup& pretokenizedGroup,
@@ -689,6 +691,21 @@ namespace kiwi
 
 		UnorderedMap<PackedState, uint32_t> spStateCnt;
 		size_t validTarget = 0;
+		KString normalizedSourceForm, normalizedAnalyzedForm;
+		auto matchesSourceSpan = [&](uint32_t begin, uint32_t end, U16StringView analyzedForm)
+		{
+			// 사이시옷처럼 인공적으로 만든 chunk는 원문 밖이나 역순 span을
+			// 가질 수 있다. 비교할 원문이 없으므로 불일치로 처리한다.
+			if (begin > end || end > normalizedStr.size()) return false;
+			// 위치 보존 정규화는 NFC 받침과 NFD 초중성을 서로 다른 내부
+			// 형태로 남길 수 있으므로 양쪽을 같은 정규형으로 맞춰 비교한다.
+			normalizedSourceForm.clear();
+			normalizeHangul(normalizedSourceForm,
+				normalizedStr.begin() + begin, normalizedStr.begin() + end);
+			normalizedAnalyzedForm.clear();
+			normalizeHangul(normalizedAnalyzedForm, analyzedForm.begin(), analyzedForm.end());
+			return normalizedSourceForm == normalizedAnalyzedForm;
+		};
 		for (size_t i = 0; i < ret.size(); ++i)
 		{
 			if (parentMap[i] < pathes.size() && spStateCnt[pathes[parentMap[i]].curState] < topN)
@@ -704,9 +721,27 @@ namespace kiwi
 			auto& rarr = ret[validTarget].first;
 
 			const KString* prevMorph = nullptr;
+			uint32_t prevNodeId = 0;
+			bool hasPreviousToken = false;
+			u16string previousJoined;
+			uint32_t previousBegin = 0, previousEnd = 0;
 			for (auto& s : r.path)
 			{
 				if (!s.str.empty() && s.str[0] == ' ') continue;
+
+				// 표면형 추적은 just_split처럼 원문 복원이 필요한 경우에만 수행한다.
+				// 일반 분석에서는 비싼 원문 대조와 Token 메타데이터 생성을 생략한다.
+				bool startsNewSurfaceForm = false;
+				if (trackSurfaceForm)
+				{
+					// graph node가 바뀌거나 한 node가 여러 chunk를 내면 새 표면형을
+					// 우선 시도하고, 아래의 원문 대조로 축약 경계만 취소한다.
+					startsNewSurfaceForm = !hasPreviousToken
+						|| s.nodeId != prevNodeId
+						|| s.hasInferredSurfaceBoundary;
+					prevNodeId = s.nodeId;
+				}
+
 				u16string joined;
 				do
 				{
@@ -731,14 +766,36 @@ namespace kiwi
 					}
 					joined = joinHangul(s.str.empty() ? *s.morph->kform : s.str);
 				} while (0);
-				
-				if (!!(matchOptions & Match::compatibleJamo))
+
+				// '했'의 하/VV+었/EP처럼 양쪽 분석형이 각자 원문 span에 존재하지
+				// 않으면 두 형태소는 하나의 축약 표면형을 공유한다.
+				bool shouldMergeWithPreviousSurface = false;
+				if (trackSurfaceForm
+					&& s.hasInferredSurfaceBoundary
+					&& hasPreviousToken)
+				{
+					shouldMergeWithPreviousSurface = !matchesSourceSpan(
+						previousBegin, previousEnd, previousJoined
+					) && !matchesSourceSpan(s.begin, s.end, joined);
+				}
+
+				if (!trackSurfaceForm && !!(matchOptions & Match::compatibleJamo))
 				{
 					toCompatibleJamo(joined);
 				}
-
 				rarr.emplace_back(joined, s.morph->tag);
 				auto& token = rarr.back();
+				if (trackSurfaceForm)
+				{
+					previousJoined = move(joined);
+					previousBegin = s.begin;
+					previousEnd = s.end;
+					if (!!(matchOptions & Match::compatibleJamo))
+					{
+						toCompatibleJamo(token.str);
+					}
+					token.isSurfaceFormStart = startsNewSurfaceForm && !shouldMergeWithPreviousSurface;
+				}
 				token.morph = within(s.morph, pretokenizedGroup.morphemes) ? nullptr : s.morph;
 				size_t beginPos = (upper_bound(positionTable.begin(), positionTable.end(), s.begin) - positionTable.begin()) - 1;
 				size_t endPos = lower_bound(positionTable.begin(), positionTable.end(), s.end) - positionTable.begin();
@@ -763,6 +820,7 @@ namespace kiwi
 				// Token의 시작위치(position)을 이용해 Token이 포함된 어절번호(wordPosition)를 얻음
 				token.wordPosition = wordPositions[token.position];
 				prevMorph = s.morph->kform;
+				if (trackSurfaceForm) hasPreviousToken = true;
 			}
 			rarr.erase(joinAffixTokens(rarr.begin(), rarr.end(), matchOptions), rarr.end());
 			ret[validTarget].second += r.score;
@@ -1041,6 +1099,8 @@ namespace kiwi
 		thread_local PretokenizedSpanGroup pretokenizedGroup;
 
 		KiwiConfig config = overrideConfig.value_or(globalConfig);
+		const bool trackSurfaceForm = !!(option.match & Match::surfaceForm);
+		const Match matchOptions = option.match & ~Match::surfaceForm;
 
 		normalizedStr.clear();
 		positionTable.clear();
@@ -1134,7 +1194,7 @@ namespace kiwi
 				formTrie,
 				U16StringView{ normalizedStr.data() + splitEnd, normalizedStr.size() - splitEnd },
 				splitEnd,
-				option.match,
+				matchOptions,
 				option.allowedDialects,
 				config.maxUnkFormSize,
 				config.maxUnkFormSizeFollowedByJClass,
@@ -1180,8 +1240,8 @@ namespace kiwi
 				(option.match & Match::oovMask) >= Match::oovChrFreqModel ? &substringCounter : nullptr
 			});
 			insertPathIntoResults(ret, spStatesByRet, oovTotalCnt,
-				res, topN, option.match, config.integrateAllomorph, 
-				positionTable, wordPositions, pretokenizedGroup, nodeInWhichPretokenized);
+				res, topN, matchOptions, config.integrateAllomorph, trackSurfaceForm,
+				normalizedStr, positionTable, wordPositions, pretokenizedGroup, nodeInWhichPretokenized);
 			if (doLogging)
 			{
 				auto duration = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - startTime).count();

--- a/src/PathEvaluator.h
+++ b/src/PathEvaluator.h
@@ -43,6 +43,7 @@ namespace kiwi
 		float wordScore = 0, typoCost = 0, dialectCost = 0;
 		uint32_t typoFormId = 0;
 		uint32_t nodeId = 0;
+		bool hasInferredSurfaceBoundary = false;
 
 		PathNode(const Morpheme* _morph = nullptr,
 			const KString& _str = {},
@@ -52,11 +53,13 @@ namespace kiwi
 			float _typoCost = 0,
 			float _dialectCost = 0,
 			uint32_t _typoFormId = 0,
-			uint32_t _nodeId = 0
+			uint32_t _nodeId = 0,
+			bool _hasInferredSurfaceBoundary = false
 		)
 			: morph{ _morph }, str{ _str }, begin{ _begin }, end{ _end },
 			wordScore{ _wordScore }, typoCost{ _typoCost }, dialectCost{ _dialectCost },
-			typoFormId{ _typoFormId }, nodeId{ _nodeId }
+			typoFormId{ _typoFormId }, nodeId{ _nodeId },
+			hasInferredSurfaceBoundary{ _hasInferredSurfaceBoundary }
 		{
 		}
 

--- a/src/PathEvaluator.hpp
+++ b/src/PathEvaluator.hpp
@@ -1130,7 +1130,8 @@ namespace kiwi
 						typoCostDiff,
 						dialectCostDiff,
 						typoCostDiff ? gNode.typoFormId : 0,
-						&gNode - graph
+						&gNode - graph,
+						ch > 0
 					);
 				}
 				ret.back().end = gNode.endPos;
@@ -1169,7 +1170,8 @@ namespace kiwi
 						typoCostDiff,
 						dialectCostDiff,
 						typoCostDiff ? gNode.typoFormId : 0,
-						&gNode - graph
+						&gNode - graph,
+						true
 					);
 				}
 				ret.back().end = gNode.endPos;
@@ -1188,7 +1190,8 @@ namespace kiwi
 						typoCostDiff,
 						dialectCostDiff,
 						typoCostDiff ? gNode.typoFormId : 0,
-						&gNode - graph
+						&gNode - graph,
+						ch > 0
 					);
 				}
 				ret.back().end = gNode.endPos;

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -517,6 +517,46 @@ TEST(KiwiCpp, Pretokenized)
 	}
 }
 
+TEST(KiwiCpp, SurfaceFormBoundaries)
+{
+	Kiwi& kiwi = reuseKiwiInstance();
+
+	auto expectBoundaries = [&](const std::u16string& text,
+		const std::vector<bool>& expected,
+		Match match = Match::allWithNormalizing)
+	{
+		auto tokens = kiwi.analyze(text, match | Match::surfaceForm).first;
+		ASSERT_EQ(tokens.size(), expected.size()) << " for input: " << utf16To8(text);
+		for (size_t i = 0; i < tokens.size(); ++i)
+		{
+			EXPECT_EQ(tokens[i].isSurfaceFormStart, expected[i])
+				<< " at token " << i << " for input: " << utf16To8(text);
+		}
+	};
+
+	expectBoundaries(u"했다", { true, false, true });
+	expectBoundaries(u"하였다", { true, true, true });
+	expectBoundaries(u"귀여워요", { true, false });
+	expectBoundaries(u"걸어", { true, true });
+
+	expectBoundaries(u"시곗바늘", { true, false, true },
+		Match::allWithNormalizing | Match::splitSaisiot);
+	expectBoundaries(u"공부하다", { true, true },
+		Match::allWithNormalizing | Match::joinAffix);
+}
+
+TEST(KiwiCpp, SurfaceFormTrackingCanBeDisabled)
+{
+	Kiwi& kiwi = reuseKiwiInstance();
+
+	auto tokens = kiwi.analyze(u"했다", Match::allWithNormalizing).first;
+	ASSERT_EQ(tokens.size(), 3u);
+	for (const auto& token : tokens)
+	{
+		EXPECT_FALSE(token.isSurfaceFormStart);
+	}
+}
+
 TEST(KiwiCpp, PretokenizedWithTypo)
 {
 	Kiwi& kiwi = reuseKiwiInstance();


### PR DESCRIPTION
## 배경

Kiwi의 분석 결과에서는 원문의 한 부분이 여러 Token으로 나뉠 수 있습니다.
예를 들어 `했다`는 `하/VV + 었/EP + 다/EF`로 분석되지만, `하`와 `었`은 모두 원문의 `했`에서 나온 Token입니다.

kiwipiepy의 `just_split`을 구현하려면 분석된 Token을 다시 원문의 조각으로 묶을 수 있어야 합니다. 하지만 일부 축약형에서는 `position`과 `length`만으로 이 관계를 안정적으로 구분하기 어렵습니다.
따라서 필요한 경우 Kiwi가 각 Token이 새로운 원문 표면형에서 시작하는지를 알려주도록 제안합니다.

이 PR은 기존 버그 수정이 아니라, 후속 `just_split` 구현에 필요한 정보를 추가하는 기능 제안입니다.

## 변경 내용

- `Match::surfaceForm` 옵션을 추가했습니다.
- 옵션을 사용하면 `TokenInfo::isSurfaceFormStart`에 각 Token이 새로운 표면형에서 시작하는지를 기록합니다.
- 축약형처럼 여러 형태소가 원문의 한 부분에서 나온 경우에는 같은 표면형으로 표시합니다.
- 옵션을 사용하지 않으면 기존 분석 결과와 동작은 바뀌지 않습니다.
- `AnalyzeOption` 구조는 변경하지 않고 `Match` 옵션으로 추가했습니다.

## 테스트

다음 경우에 대한 C++ 테스트를 추가했습니다.

- `했다`와 `하였다`
- 활용형과 축약형
- 사이시옷 분리
- 접사 결합
- 옵션을 사용하지 않은 일반 분석

## 관련 작업

`pretokenized` 입력 범위 검증 문제는 별도의 kiwipiepy PR로 분리했습니다.
> bab2min/kiwipiepy#225

두 PR은 서로 독립적입니다. 이 기능이 받아들여지면 Python 쪽 연결과 `just_split`은 후속 PR로 제안하겠습니다.