### PR TITLE
fix: Mark the wasm npm package as an ES module

### DIFF
--- a/bindings/wasm/package/package.json
+++ b/bindings/wasm/package/package.json
@@ -6,6 +6,7 @@
         "type": "git",
         "url": "git+https://github.com/bab2min/Kiwi.git"
     },
+    "type": "module",
     "main": "dist/index.js",
     "files": [
         "dist"

--- a/bindings/wasm/package/test/kiwi.test.ts
+++ b/bindings/wasm/package/test/kiwi.test.ts
@@ -3,7 +3,9 @@ import { KiwiBuilder } from '../src/index.js';
 import { Kiwi, Match } from '../src/kiwi.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, '../../../../');
 const WASM_PATH = path.resolve(PROJECT_ROOT, 'bindings/wasm/build/bindings/wasm/kiwi-wasm.wasm');
 const MODEL_DIR = path.resolve(PROJECT_ROOT, 'models/cong/base');


### PR DESCRIPTION
The package is built with `tsc` using `"module": "es6"`, so `dist`
contains ES module syntax with `.js` import specifiers. But
`package.json` has no `"type"` field, so Node treats those files as
CommonJS by default. Node only works today because it falls back to
"reparse as ES module because module syntax was detected", which emits a
MODULE_TYPELESS_PACKAGE_JSON warning. Stricter toolchains (for example
tsx) fail when importing `kiwi-nlp` with a "does not provide an export
name 'KiwiBuilder'" error message.

Adding `"type": "module"` declares the package's true format, removes
the warning, and makes it consumable from ESM toolchains without relying
on Node's fallback.

Because the package is now genuinely ESM, `__dirname` is no longer
defined in the test file so we have to derive it from `import.meta.url`
instead.

