### PR TITLE
최적화 splitter 사용 시 non-BMP 문자 경계 분석 오류 수정

### DIFF
--- a/src/KTrie.cpp
+++ b/src/KTrie.cpp
@@ -1027,6 +1027,23 @@ public:
 		}
 
 		auto lengtheningTypoNodes = state.getLengtheningTypoNodes();
+		// 장음화 오타 비용(lengtheningTypoCost * (3 + lengtheningSize))은 lengtheningSize에 대해 단조 증가하므로,
+		// 남은 오타 비용 예산으로부터 더 이상 장음화를 탐색할 필요가 없는 지점을 미리 정할 수 있다.
+		static constexpr size_t lengtheningSizeLimit = 8;
+		size_t maxLengtheningSize = 0;
+		if constexpr (lengtheningTypoTolerant)
+		{
+			if (lengtheningTypoCost > 0)
+			{
+				// TODO: 하드코딩된 장음화 오타 비용 계산식을 다른 곳과 연계하여 계산하도록 수정 필요
+				const float budget = (typoThreshold - typoCost) / lengtheningTypoCost - 3;
+				maxLengtheningSize = budget < 1 ? 0 : min(lengtheningSizeLimit, (size_t)budget);
+			}
+			else
+			{
+				maxLengtheningSize = lengtheningSizeLimit;
+			}
+		}
 		auto* curNode = state.node;
 		for (size_t j = 0; j < typoNode.form.size(); ++j)
 		{
@@ -1243,8 +1260,7 @@ public:
 				};
 
 				const size_t prevLengtheningSize = lengtheningTypoNodes.size();
-				static constexpr size_t maxLengtheningSize = 8;
-				if (prevChr && isHangulSyllable(prevChr) &&
+				if (maxLengtheningSize && prevChr && isHangulSyllable(prevChr) &&
 					(u'아' <= c && c < u'자') && lengtheningVowelTable[extractVowel(prevChr)] == extractVowel(c))
 				{
 					lengtheningTypoNodes.emplace_back(1, curNode);
@@ -1294,56 +1310,43 @@ public:
 				if (nextNode)
 				{
 					curNode = nextNode;
-					const bool isLastCodeUnit = k + 1 == codeUnitSize;
-					// 오타가 있는 경우 전체 형태가 포함된 후보만 탐색.
-					if (isLastCodeUnit && (typoNode.typoCost == 0 || j + codeUnitSize == typoNode.form.size()))
-					{
-						if (typoCost > 0 && curNode->depth < minFormLen)
-						{
-							// early pruning
-						}
-						else
-						{
-							for (auto submatcher = curNode; submatcher; submatcher = submatcher->fail())
-							{
-								const Form* cand = submatcher->val(trie);
-								if (!cand) break;
-								else if (!trie.hasSubmatch(cand))
-								{
-									if (cand->form.size() < minFormLen) break;
-									candidates.emplace_back(cand);
-								}
-							}
-						}
-
-						if constexpr (lengtheningTypoTolerant)
-						{
-							for (auto [lengtheningSize, node] : lengtheningTypoNodes)
-							{
-								const Form* cand = node->val(trie);
-								if (cand && !trie.hasSubmatch(cand))
-								{
-									if (cand->form.size() < minFormLen) continue;
-									candidates.emplace_back(cand, lengtheningSize);
-								}
-							}
-						}
-					}
 				}
 				else
 				{
-					if constexpr (lengtheningTypoTolerant)
+					if (typoCost > 0) return;
+					curNode = trie.root();
+				}
+
+				const bool isLastCodeUnit = k + 1 == codeUnitSize;
+				// 오타가 있는 경우 전체 형태가 포함된 후보만 탐색.
+				if (isLastCodeUnit && (typoNode.typoCost == 0 || j + codeUnitSize == typoNode.form.size()))
+				{
+					if (nextNode && !(typoCost > 0 && curNode->depth < minFormLen)) // typoCost > 0인 경우 early pruning
 					{
-						lengtheningTypoNodes.clear();
+						for (auto submatcher = curNode; submatcher; submatcher = submatcher->fail())
+						{
+							const Form* cand = submatcher->val(trie);
+							if (!cand) break;
+							else if (!trie.hasSubmatch(cand))
+							{
+								if (cand->form.size() < minFormLen) break;
+								candidates.emplace_back(cand);
+							}
+						}
 					}
 
-					if (typoCost == 0)
+					// 장음화 노드는 메인 탐색과 독립적인 경로이므로 메인 탐색과 무관하게 후보를 수집함.
+					if constexpr (lengtheningTypoTolerant)
 					{
-						curNode = trie.root();
-					}
-					else
-					{
-						return;
+						for (auto [lengtheningSize, node] : lengtheningTypoNodes)
+						{
+							const Form* cand = node->val(trie);
+							if (cand && !trie.hasSubmatch(cand))
+							{
+								if (cand->form.size() < minFormLen) continue;
+								candidates.emplace_back(cand, lengtheningSize);
+							}
+						}
 					}
 				}
 			}

--- a/src/KTrie.cpp
+++ b/src/KTrie.cpp
@@ -1044,6 +1044,18 @@ public:
 				maxLengtheningSize = lengtheningSizeLimit;
 			}
 		}
+		// 패턴 커서는 Splitter 멤버로 공유하면 안 된다. 오타 교정이 켜진 경우 같은 위치를 여러 분기가
+		// 각각 훑는데, 먼저 도달한 분기가 커서를 소비해버리면 이후 분기가 잘못된 패턴을 보게 된다.
+		// 호출 단위로 유지하면 currentPos가 j에 대해 단조 증가하므로, 진입 시 한 번만 이분 탐색하고
+		// 이후에는 증분 전진으로 문자당 O(1)에 처리할 수 있다.
+		const size_t basePos = typoNode.endPos - typoNode.form.size();
+		auto matchedPattern = matchedPatterns.cend();
+		if (typoCost == 0)
+		{
+			matchedPattern = upper_bound(matchedPatterns.cbegin(), matchedPatterns.cend(), basePos,
+				[](size_t pos, const auto& pattern) { return pos < get<0>(pattern); });
+		}
+
 		auto* curNode = state.node;
 		for (size_t j = 0; j < typoNode.form.size(); ++j)
 		{
@@ -1054,13 +1066,15 @@ public:
 				c32 = mergeSurrogate(c32, typoNode.form[j + 1]);
 			}
 
-			auto matchedPattern = matchedPatterns.cend();
 			bool isInPattern = false;
 			if (typoCost == 0)
 			{
-				const size_t currentPos = typoNode.endPos + j - typoNode.form.size();
-				matchedPattern = upper_bound(matchedPatterns.cbegin(), matchedPatterns.cend(), currentPos,
-					[](size_t pos, const auto& pattern) { return pos < get<0>(pattern); });
+				const size_t currentPos = basePos + j;
+				// 이미 지나친 패턴을 건너뛴다.
+				while (matchedPattern != matchedPatterns.cend() && get<0>(*matchedPattern) <= currentPos)
+				{
+					++matchedPattern;
+				}
 				isInPattern = matchedPattern != matchedPatterns.cend() &&
 					currentPos >= get<0>(*matchedPattern) - get<1>(*matchedPattern);
 

--- a/src/KTrie.cpp
+++ b/src/KTrie.cpp
@@ -732,7 +732,6 @@ public:
 	U16StringView rawStr;
 	size_t posMultiplierBit = 0;
 	float lengtheningTypoCost = 0;
-	Vector<tuple<size_t, uint32_t, POSTag>>::const_iterator nextMatchedPattern;
 
 	void init(
 		const Form* formBase,
@@ -853,7 +852,6 @@ public:
 		}
 		posToNs.emplace_back(nsToPos.size());
 		sort(matchedPatterns.begin(), matchedPatterns.end());
-		nextMatchedPattern = matchedPatterns.begin();
 		return n;
 	}
 
@@ -1039,10 +1037,15 @@ public:
 				c32 = mergeSurrogate(c32, typoNode.form[j + 1]);
 			}
 
+			auto matchedPattern = matchedPatterns.cend();
+			bool isInPattern = false;
 			if (typoCost == 0)
 			{
-				const bool isInPattern = nextMatchedPattern != matchedPatterns.end() &&
-					(typoNode.endPos + j - typoNode.form.size()) >= get<0>(*nextMatchedPattern) - get<1>(*nextMatchedPattern);
+				const size_t currentPos = typoNode.endPos + j - typoNode.form.size();
+				matchedPattern = upper_bound(matchedPatterns.cbegin(), matchedPatterns.cend(), currentPos,
+					[](size_t pos, const auto& pattern) { return pos < get<0>(pattern); });
+				isInPattern = matchedPattern != matchedPatterns.cend() &&
+					currentPos >= get<0>(*matchedPattern) - get<1>(*matchedPattern);
 
 				POSTag chrType = identifySpecialChr(c32);
 				ScriptType scriptType = chr2ScriptType(c32);
@@ -1104,8 +1107,8 @@ public:
 				}
 				else
 				{
-					// 공백 문자
-					if (chrType == POSTag::unknown)
+					// 공백 및 경계로 취급하는 문자
+					if (chrType == POSTag::unknown && !isInPattern)
 					{
 						if (lastSpaceBoundaryNsPos < unkFormStartNsPos)
 						{
@@ -1145,12 +1148,12 @@ public:
 				}
 			}
 
-			if (typoNode.typoCost == 0 && nextMatchedPattern != matchedPatterns.end())
+			if (typoNode.typoCost == 0 && matchedPattern != matchedPatterns.cend())
 			{
 				const auto currentEnd = typoNode.endPos + j + (c32 >= 0x10000 ? 2 : 1) - typoNode.form.size();
-				while (nextMatchedPattern != matchedPatterns.end() && get<0>(*nextMatchedPattern) == currentEnd)
+				while (matchedPattern != matchedPatterns.cend() && get<0>(*matchedPattern) == currentEnd)
 				{
-					const auto [matchedEnd, matchedLength, matchedType] = *nextMatchedPattern;
+					const auto [matchedEnd, matchedLength, matchedType] = *matchedPattern;
 					const auto matchedStart = matchedEnd - matchedLength;
 					if (lastSpaceBoundaryNsPos < unkFormStartNsPos)
 					{
@@ -1171,7 +1174,8 @@ public:
 					{
 						out.back().form = trie.value((size_t)matchedType);
 					}
-					++nextMatchedPattern;
+					lastSpaceBoundaryNsPos = specialStartNsPos = unkFormStartNsPos = posToNs[matchedEnd];
+					++matchedPattern;
 				}
 			}
 			if (typoNode.typoCost == 0 && nextPretokenizedPattern != lastPretokenizedPattern
@@ -1211,13 +1215,7 @@ public:
 				specialStartNsPos = unkFormStartNsPos = lastSpaceBoundaryNsPos = posToNs[typoNode.endPos + j + 1 - typoNode.form.size()];
 				continue;
 			}
-			if (c32 >= 0x10000)
-			{
-				++j;
-				prevChr = c32;
-				continue;
-			}
-
+			const size_t codeUnitSize = c32 >= 0x10000 ? 2 : 1;
 			if constexpr (lengtheningTypoTolerant)
 			{
 				static uint8_t lengtheningVowelTable[] = {
@@ -1264,7 +1262,10 @@ public:
 				for (size_t i = 0; i < prevLengtheningSize; ++i)
 				{
 					auto& node = lengtheningTypoNodes[i];
-					node.second = node.second->template nextOpt<arch>(trie, c);
+					for (size_t k = 0; k < codeUnitSize && node.second; ++k)
+					{
+						node.second = node.second->template nextOpt<arch>(trie, typoNode.form[j + k]);
+					}
 					if (!node.second) continue;
 					if (find(lengtheningTypoNodes.begin(), lengtheningTypoNodes.begin() + outputIdx, node) != lengtheningTypoNodes.begin() + outputIdx) continue;
 					lengtheningTypoNodes[outputIdx++] = node;
@@ -1277,70 +1278,76 @@ public:
 				}
 				lengtheningTypoNodes.erase(lengtheningTypoNodes.begin() + outputIdx, lengtheningTypoNodes.end());
 			}
-			prevChr = c32;
+			prevChr = isInPattern ? 0 : c32;
 
-			if (minFormLen > 0 || typoNode.typoCost > 0) ++minFormLen;
-			auto* nextNode = curNode->template nextOpt<arch>(trie, c);
-			while (!nextNode)
+			for (size_t k = 0; k < codeUnitSize; ++k)
 			{
-				curNode = curNode->fail();
-				if (!curNode) break;
-				nextNode = curNode->template nextOpt<arch>(trie, c);
-			}
-			if (nextNode)
-			{
-				curNode = nextNode;
-				// 오타가 있는 경우 전체 형태가 포함된 후보만 탐색.
-				if (typoNode.typoCost == 0 || j == typoNode.form.size() - 1)
+				if (minFormLen > 0 || typoNode.typoCost > 0) ++minFormLen;
+				const char16_t trieChr = typoNode.form[j + k];
+				auto* nextNode = curNode->template nextOpt<arch>(trie, trieChr);
+				while (!nextNode)
 				{
-					if (typoCost > 0 && curNode->depth < minFormLen)
+					curNode = curNode->fail();
+					if (!curNode) break;
+					nextNode = curNode->template nextOpt<arch>(trie, trieChr);
+				}
+				if (nextNode)
+				{
+					curNode = nextNode;
+					const bool isLastCodeUnit = k + 1 == codeUnitSize;
+					// 오타가 있는 경우 전체 형태가 포함된 후보만 탐색.
+					if (isLastCodeUnit && (typoNode.typoCost == 0 || j + codeUnitSize == typoNode.form.size()))
 					{
-						// early pruning
-					}
-					else
-					{
-						for (auto submatcher = curNode; submatcher; submatcher = submatcher->fail())
+						if (typoCost > 0 && curNode->depth < minFormLen)
 						{
-							const Form* cand = submatcher->val(trie);
-							if (!cand) break;
-							else if (!trie.hasSubmatch(cand))
+							// early pruning
+						}
+						else
+						{
+							for (auto submatcher = curNode; submatcher; submatcher = submatcher->fail())
 							{
-								if (cand->form.size() < minFormLen) break;
-								candidates.emplace_back(cand);
+								const Form* cand = submatcher->val(trie);
+								if (!cand) break;
+								else if (!trie.hasSubmatch(cand))
+								{
+									if (cand->form.size() < minFormLen) break;
+									candidates.emplace_back(cand);
+								}
+							}
+						}
+
+						if constexpr (lengtheningTypoTolerant)
+						{
+							for (auto [lengtheningSize, node] : lengtheningTypoNodes)
+							{
+								const Form* cand = node->val(trie);
+								if (cand && !trie.hasSubmatch(cand))
+								{
+									if (cand->form.size() < minFormLen) continue;
+									candidates.emplace_back(cand, lengtheningSize);
+								}
 							}
 						}
 					}
-
-					if constexpr (lengtheningTypoTolerant)
-					{
-						for (auto [lengtheningSize, node] : lengtheningTypoNodes)
-						{
-							const Form* cand = node->val(trie);
-							if (cand && !trie.hasSubmatch(cand))
-							{
-								if (cand->form.size() < minFormLen) continue;
-								candidates.emplace_back(cand, lengtheningSize);
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				if constexpr (lengtheningTypoTolerant)
-				{
-					lengtheningTypoNodes.clear();
-				}
-
-				if (typoCost == 0)
-				{
-					curNode = trie.root();
 				}
 				else
 				{
-					return;
+					if constexpr (lengtheningTypoTolerant)
+					{
+						lengtheningTypoNodes.clear();
+					}
+
+					if (typoCost == 0)
+					{
+						curNode = trie.root();
+					}
+					else
+					{
+						return;
+					}
 				}
 			}
+			j += codeUnitSize - 1;
 
 			const size_t endPos = typoNode.endPos + j + 1 - typoNode.form.size();
 			flushCandidates<lengtheningTypoTolerant>(posToNs[endPos], 

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -394,18 +394,24 @@ TEST(KiwiCpp, ChineseVsEmoji)
 TEST(KiwiCpp, NonBmpBoundaries)
 {
 	Kiwi& kiwi = reuseKiwiInstance();
-	AnalyzeOption typoOption = Match::allWithNormalizing;
-	typoOption.typoTransformer = getDefaultPreparedTypoSet(DefaultTypoSet::basicTypoSetWithContinualAndLengthening);
+
+	std::array<AnalyzeOption, 2> options = {
+		Match::allWithNormalizing,
+		Match::allWithNormalizing,
+	};
+	options[1].typoTransformer = getDefaultPreparedTypoSet(DefaultTypoSet::basicTypoSetWithContinualAndLengthening);
+
+	using TupleType = std::tuple<std::u16string, std::u16string, POSTag>;
 	for (auto& [str, specialForm, specialTag] : {
-		std::tuple{ std::u16string{ u"랠프𐐷에머슨" }, std::u16string{ u"𐐷" }, POSTag::sw },
-		std::tuple{ std::u16string{ u"랠프😀에머슨" }, std::u16string{ u"😀" }, POSTag::w_emoji },
-		std::tuple{ std::u16string{ u"랠프👍🏽에머슨" }, std::u16string{ u"👍🏽" }, POSTag::w_emoji },
+		TupleType{ u"랠프𐐷에머슨", u"𐐷", POSTag::sw },
+		TupleType{ u"랠프😀에머슨", u"😀", POSTag::w_emoji },
+		TupleType{ u"랠프👍🏽에머슨", u"👍🏽", POSTag::w_emoji },
 	})
 	{
-		for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+		for (auto& option : options)
 		{
 			auto res = kiwi.analyze(str, option).first;
-			ASSERT_EQ(res.size(), 3);
+			ASSERT_EQ(res.size(), 3) << " for string: " << utf16To8(str);
 			EXPECT_EQ(res[0].str, u"랠프");
 			EXPECT_EQ(res[0].position, 0);
 			EXPECT_EQ(res[0].length, 2);
@@ -418,7 +424,8 @@ TEST(KiwiCpp, NonBmpBoundaries)
 			EXPECT_EQ(res[2].length, 3);
 		}
 	}
-	for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+
+	for (auto& option : options)
 	{
 		auto res = kiwi.analyze(u"😀랠프", option).first;
 		ASSERT_EQ(res.size(), 2);
@@ -428,11 +435,11 @@ TEST(KiwiCpp, NonBmpBoundaries)
 		EXPECT_EQ(res[1].tag, POSTag::nnp);
 	}
 
-	const std::vector<std::u16string> userWords = {
-		std::u16string{ u"가𐐷나" },
-		std::u16string{ u"가😀나" },
-		std::u16string{ u"랠프👍🏽에머슨" },
-		std::u16string{ u"가👨‍👩‍👧‍👦나" },
+	const std::initializer_list<std::u16string> userWords = {
+		u"가𐐷나",
+		u"가😀나",
+		u"랠프👍🏽에머슨",
+		u"가👨‍👩‍👧‍👦나",
 	};
 	KiwiBuilder builder{ MODEL_PATH, 0, BuildOption::default_ };
 	for (auto& str : userWords)
@@ -442,7 +449,7 @@ TEST(KiwiCpp, NonBmpBoundaries)
 	auto userWordKiwi = builder.build();
 	for (auto& str : userWords)
 	{
-		for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+		for (auto& option : options)
 		{
 			auto res = userWordKiwi.analyze(str, option).first;
 			ASSERT_EQ(res.size(), 1);
@@ -451,6 +458,21 @@ TEST(KiwiCpp, NonBmpBoundaries)
 			EXPECT_EQ(res[0].position, 0);
 			EXPECT_EQ(res[0].length, str.size());
 		}
+	}
+	// 오타 교정 사례에 대한 테스트
+	for (auto s : {
+		u"가아𐐷나",
+		u"가𐐷나아",
+		u"가아😀나",
+		u"가😀나아",
+		u"렐프👍🏽에머슨",
+		u"가아👨‍👩‍👧‍👦나아",
+		})
+	{
+		auto res = userWordKiwi.analyze(s, options[1]).first;
+		EXPECT_EQ(res.size(), 1);
+		EXPECT_EQ(res[0].tag, POSTag::nnp);
+		EXPECT_EQ(res[0].position, 0);
 	}
 }
 

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -391,6 +391,69 @@ TEST(KiwiCpp, ChineseVsEmoji)
 	EXPECT_EQ(res[3].tag, POSTag::w_emoji);
 }
 
+TEST(KiwiCpp, NonBmpBoundaries)
+{
+	Kiwi& kiwi = reuseKiwiInstance();
+	AnalyzeOption typoOption = Match::allWithNormalizing;
+	typoOption.typoTransformer = getDefaultPreparedTypoSet(DefaultTypoSet::basicTypoSetWithContinualAndLengthening);
+	for (auto& [str, specialForm, specialTag] : {
+		std::tuple{ std::u16string{ u"랠프𐐷에머슨" }, std::u16string{ u"𐐷" }, POSTag::sw },
+		std::tuple{ std::u16string{ u"랠프😀에머슨" }, std::u16string{ u"😀" }, POSTag::w_emoji },
+		std::tuple{ std::u16string{ u"랠프👍🏽에머슨" }, std::u16string{ u"👍🏽" }, POSTag::w_emoji },
+	})
+	{
+		for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+		{
+			auto res = kiwi.analyze(str, option).first;
+			ASSERT_EQ(res.size(), 3);
+			EXPECT_EQ(res[0].str, u"랠프");
+			EXPECT_EQ(res[0].position, 0);
+			EXPECT_EQ(res[0].length, 2);
+			EXPECT_EQ(res[1].str, specialForm);
+			EXPECT_EQ(res[1].tag, specialTag);
+			EXPECT_EQ(res[1].position, 2);
+			EXPECT_EQ(res[1].length, specialForm.size());
+			EXPECT_EQ(res[2].str, u"에머슨");
+			EXPECT_EQ(res[2].position, 2 + specialForm.size());
+			EXPECT_EQ(res[2].length, 3);
+		}
+	}
+	for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+	{
+		auto res = kiwi.analyze(u"😀랠프", option).first;
+		ASSERT_EQ(res.size(), 2);
+		EXPECT_EQ(res[0].str, u"😀");
+		EXPECT_EQ(res[0].tag, POSTag::w_emoji);
+		EXPECT_EQ(res[1].str, u"랠프");
+		EXPECT_EQ(res[1].tag, POSTag::nnp);
+	}
+
+	const std::vector<std::u16string> userWords = {
+		std::u16string{ u"가𐐷나" },
+		std::u16string{ u"가😀나" },
+		std::u16string{ u"랠프👍🏽에머슨" },
+		std::u16string{ u"가👨‍👩‍👧‍👦나" },
+	};
+	KiwiBuilder builder{ MODEL_PATH, 0, BuildOption::default_ };
+	for (auto& str : userWords)
+	{
+		EXPECT_TRUE(builder.addWord(str, POSTag::nnp, 20).second);
+	}
+	auto userWordKiwi = builder.build();
+	for (auto& str : userWords)
+	{
+		for (auto option : { AnalyzeOption{ Match::allWithNormalizing }, typoOption })
+		{
+			auto res = userWordKiwi.analyze(str, option).first;
+			ASSERT_EQ(res.size(), 1);
+			EXPECT_EQ(res[0].str, str);
+			EXPECT_EQ(res[0].tag, POSTag::nnp);
+			EXPECT_EQ(res[0].position, 0);
+			EXPECT_EQ(res[0].length, str.size());
+		}
+	}
+}
+
 TEST(KiwiCpp, Script)
 {
 	Kiwi& kiwi = reuseKiwiInstance();


### PR DESCRIPTION
안녕하세요. `Kiwi.split` PR을 준비하고 테스트하는 과정에서 별도의 버그를 발견하여 이 PR을 작성합니다.

솔직히 말씀드리면 C++을 다룬 지 오래되어, 이번 수정이 메인테이너 관점에서도 정확하고 적절한 방식인지 제가 온전히 판단하기는 어렵습니다. 수정 코드와 아래 설명은 Codex와 함께 작성했고 제가 여러 차례 검증했지만, 코드의 방향과 수정 범위가 적절한지 메인테이너분께서 한 번 검토해 주시면 감사하겠습니다.

---

## 문제

최적화된 splitter가 이모지처럼 UTF-16에서 두 칸을 차지하는 non-BMP 문자를 만날 때, 해당 문자를 사이에 둔 형태를 잘못 연결할 수 있습니다.

예를 들어 `랠프 에머슨`이 사전에 등록되어 있을 때 `랠프😀에머슨`을 분석하면 기존 결과는 다음과 같이 이모지를 건너뛴 형태를 후보로 사용할 수 있습니다.

```text
기존: [(''랠'', ''NNP''), (''랠프 에머슨'', ''NNP'')]
수정: [(''랠프'', ''NNP''), (''😀'', ''W_EMOJI''), (''에머슨'', ''NNP'')]
```

반대로 non-BMP 문자를 실제로 포함하는 사용자 사전어를 등록한 경우에도 최적화된 splitter에서는 해당 단어를 하나의 형태로 인식하지 못했습니다.

```text
등록: 가😀나 / NNP

기존: [(''가'', ...), (''😀'', ''W_EMOJI''), (''나'', ...)]
수정: [(''가😀나'', ''NNP'')]
```

ZWJ로 결합된 이모지를 포함하는 사용자 사전어에서도 같은 문제가 발생했습니다.

## 원인

Kiwi 내부 문자열은 UTF-16 단위로 저장됩니다.

기존 최적화 splitter는 surrogate pair를 하나의 Unicode 문자로 결합하여 문자 종류와 패턴을 판별한 뒤, Trie 탐색에서는 이를 구성하는 두 UTF-16 code unit을 처리하지 않고 건너뛰었습니다.

그 결과 이전 Trie 탐색 상태가 non-BMP 문자 뒤까지 유지되어 앞뒤 형태가 잘못 연결되었으며, 반대로 non-BMP 문자를 명시적으로 포함하는 사전 항목은 Trie에서 끝까지 탐색할 수 없었습니다.

또한 패턴 위치를 나타내는 포인터가 오타 그래프의 여러 탐색 상태에서 공유되고 있어, 동일한 원문 위치를 처리하는 상태마다 패턴 경계를 일관되게 반영하기 어려운 부분이 있었습니다.

## 기존 non-BMP 수정과의 관계

이 문제는 kiwipiepy의 [PR #226](https://github.com/bab2min/kiwipiepy/pull/226)에서 수정한 문제와는 별개의 원인입니다.

PR #226은 `pretokenized`로 지정한 form이 원문과 다를 때, Kiwi가 반환한 UTF-16 위치를 Python 문자열 위치로 변환하는 과정에서 발생하는 오류를 수정합니다. 해당 수정은 `kiwipiepy/src/KiwiPy.cpp`의 Python 바인딩 계층에 적용됩니다.

이번 수정은 그보다 앞선 Kiwi 코어의 최적화 splitter에서 non-BMP 문자가 Trie 탐색에 전달되지 않는 문제를 수정하며, `Kiwi/src/KTrie.cpp`에 적용됩니다.

따라서 두 수정은 같은 non-BMP 입력에서 드러날 수 있지만 서로 다른 계층을 수정합니다.

- PR #226만 적용하면 `pretokenized` 결과의 Python 위치는 고쳐지지만 일반 splitter의 잘못된 형태 연결은 남습니다.
- 이번 수정만 적용하면 일반 분석과 사용자 사전어 처리는 고쳐지지만, 원문과 다른 form을 지정한 `pretokenized` 결과의 Python 위치 변환 문제는 남습니다.
- 두 수정 사이에 선행 관계는 없으며 각각 독립적으로 적용할 수 있습니다.

## 변경 내용

- non-BMP 문자를 구성하는 두 UTF-16 code unit을 모두 Trie 탐색에 전달합니다.
- surrogate pair의 마지막 code unit까지 처리한 뒤 형태 후보를 확인합니다.
- 패턴 포함 여부를 공유 포인터가 아닌 원문 위치를 기준으로 각 탐색 상태에서 확인합니다.
- 이모지 패턴이 끝난 위치를 미등록어와 특수문자 경계에도 반영합니다.
- ZWJ와 skin-tone modifier가 포함된 이모지 및 이를 포함하는 사용자 사전어를 보존합니다.

## 테스트

- supplementary symbol, 일반 이모지, skin-tone modifier, ZWJ 결합 이모지에서 경계가 유지되는지 확인했습니다.
- non-BMP 문자가 형태의 앞과 중간, 뒤에 있는 경우를 확인했습니다.
- non-BMP 문자를 명시적으로 포함하는 사용자 사전어가 하나의 형태로 분석되는지 확인했습니다.
- 일반 분석과 오타 교정 분석을 모두 확인했습니다.
- 최적화된 splitter와 기존 splitter를 일반 입력 34개 및 사용자 사전어 10개에서 비교했습니다.
- Kiwi C++ 테스트 121개와 kiwipiepy 호환성 테스트 83개가 모두 통과했습니다.

수정 전에는 non-BMP 문자를 건너뛴 형태 후보가 생성되거나 사용자 사전어가 분리되었고, 수정 후에는 non-BMP 문자 경계와 명시적으로 등록된 형태가 모두 원문에 맞게 처리됩니다.