### PR TITLE
Support 16 KB page size in Android AAR build

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -33,6 +33,15 @@ if(ANDROID)
     )
 
     target_compile_options(${pkg_name} PRIVATE -O3)
+
+    # Align the shared library to 16 KB pages. Google Play requires apps to
+    # support 16 KB page size, and a library built with the default 4 KB
+    # alignment makes the whole app rejected at upload time.
+    # 16 KB aligned libraries still run on existing 4 KB devices.
+    target_link_options(${pkg_name} PRIVATE
+        "-Wl,-z,max-page-size=16384"
+        "-Wl,-z,common-page-size=16384"
+    )
 else()
     if(UNIX AND NOT APPLE)
         target_link_libraries( ${pkg_name}

--- a/bindings/java/build.gradle
+++ b/bindings/java/build.gradle
@@ -13,6 +13,9 @@ apply plugin: 'com.android.library'
 android {
     namespace 'kr.pe.bab2min.kiwi'
     compileSdk 34
+    // 16 KB page alignment requires NDK r27 or later. Without pinning it,
+    // the build may silently pick an older NDK and drop the link options.
+    ndkVersion '27.1.12297006'
 
     defaultConfig {
         minSdk 21

--- a/bindings/java/gradle/wrapper/gradle-wrapper.properties
+++ b/bindings/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
안녕하세요. Kiwi를 모바일 앱에 붙여 쓰고 있는 사용자입니다.

#221 에서 모바일 쪽 피드백을 환영한다고 하셔서, 저희가 자체적으로 해결했던 안드로이드 빌드 문제를 정리해 보냅니다.

## 배경

Google Play가 앱에 **16KB 메모리 페이지 지원**을 요구하고 있습니다. 최신 안드로이드 기기가 4KB에서 16KB 페이지로 넘어가면서 생긴 요건입니다.

현재 `kiwi-android-v0.23.2.aar` 안의 `libKiwiJava.so`는 기본값인 4KB로 정렬돼 있어서, 이 AAR을 포함한 앱은 **Play Console 업로드 단계에서 거부됩니다.** 즉 지금은 Kiwi를 안드로이드 앱에 넣으면 스토어에 올릴 수가 없습니다.

저희도 앱 출시 준비 중에 이 문제를 만나 로컬에서 패치해 재빌드했고, 그 패치를 정리해 올립니다.

## 변경 내용

세 가지가 사슬로 이어져 있습니다.

**1. `bindings/java/CMakeLists.txt` — 16KB 정렬 링크 옵션 (핵심)**

```cmake
target_link_options(${pkg_name} PRIVATE
    "-Wl,-z,max-page-size=16384"
    "-Wl,-z,common-page-size=16384"
)
```

`if(ANDROID)` 블록 안에만 넣어서 다른 플랫폼 빌드에는 영향이 없습니다.

**2. `bindings/java/build.gradle` — NDK 버전 고정**

```gradle
ndkVersion '27.1.12297006'
```

16KB 정렬은 **NDK r27 이상**에서 지원됩니다. 버전을 명시하지 않으면 빌드 환경에 따라 구버전 NDK가 선택되어 링크 옵션이 조용히 무시될 수 있습니다. 고쳤다고 생각했는데 실제로는 안 고쳐진 상태가 되는 것이 이 문제의 까다로운 점입니다.

**3. `bindings/java/gradle/wrapper/gradle-wrapper.properties` — Gradle 8.0 → 8.5**

NDK r27을 쓰려면 그것을 지원하는 Android Gradle Plugin이 필요하고, 그 AGP가 Gradle 8.5 이상을 요구합니다. 2번을 위한 전제 조건입니다.

## 호환성

16KB 정렬된 공유 라이브러리는 **기존 4KB 페이지 기기에서도 그대로 동작합니다.** 정렬 단위를 키우는 것이라 하위 호환이 유지되며, 파일 크기가 약간 늘어나는 것 외에 런타임 동작은 달라지지 않습니다.

## 검증한 내용

- `arm64-v8a`, `x86_64` 두 ABI로 AAR 빌드 성공 (NDK 27.1.12297006, Gradle 8.5, JDK 21)
- 빌드된 `libKiwiJava.so`가 16KB 정렬됨을 확인
- 이 AAR을 실제 React Native 앱에 넣어 형태소 분석이 정상 동작함을 확인 (명사 추출 API를 실사용 경로에서 호출)
- arm64 실기기(4KB 페이지)에서 기존과 동일하게 동작

## 검증 범위에 대해

CONTRIBUTING.md의 테스트 요구사항과 관련해 범위를 밝혀둡니다.

- `test/` 아래의 C++ 코어 테스트는 **이 변경과 무관합니다.** 소스 코드를 수정하지 않고 링크 옵션과 빌드 도구 버전만 바꿨습니다.
- 안드로이드는 현재 CI 워크플로가 없어 기존에도 자동 검증 대상이 아닙니다. 그래서 저희가 할 수 있는 검증은 실제 AAR 빌드와 앱 통합 동작 확인이었고, 그것을 위와 같이 수행했습니다.
- `x86_64`는 빌드까지만 확인했고 에뮬레이터 실행 검증은 하지 못했습니다.

추가로 확인이 필요한 항목이 있으면 알려주세요. 맞춰서 진행하겠습니다.

## Gradle 버전 상향에 대해

3번이 부담스러우시면 **1·2번만 반영하셔도 됩니다.**

저희는 Gradle 8.5 + AGP + NDK 27.1 조합에서 검증했습니다. 현재의 Gradle 8.0 + AGP 8.1.4 조합에서 NDK 27이 정상 동작하는지는 **확인하지 못했습니다.** 만약 기존 버전으로도 16KB 정렬이 적용된다면 3번은 불필요합니다.

목표는 16KB 정렬이 upstream에 들어가는 것이지 Gradle 버전 자체가 아니므로, 더 작은 변경으로 되신다면 그쪽이 낫다고 생각합니다.

좋은 라이브러리 만들어주셔서 감사합니다.
